### PR TITLE
don't force static, go with the flow.

### DIFF
--- a/atc-router.go
+++ b/atc-router.go
@@ -1,6 +1,6 @@
 package goatcrouter
 
-// #cgo LDFLAGS: -L/tmp/lib -Wl,-Bstatic -latc_router -Wl,-Bdynamic
+// #cgo LDFLAGS: -L/tmp/lib -latc_router
 // #include "atc-router.h"
 import "C"
 


### PR DESCRIPTION
the current linker flags specify this sequence:
- switch to static linking.
- pull the ATC library.
- switch to dynamic.

the last switch allows the Go compiler to link the base libraries (std libraries, language, and OS) as dynamic, which works well if the "main" linking is dynamic.

both `go run` and `go test` default to dynamic, so this works.  but the `go build`, as used for the koko Dockerfile, uses a global static flag, making this sequence end in the wrong state.  in consequence, the base libraries aren't linked properly.

this PR removes the mode switches, meaning that the ATC library would be linked in the "main" mode.  for a static build it's the same, but for dynamic linking it requires not only that the `libatc_router.so` file is present, but also that it's available at runtime from the default directories.

to make both tests and builds to work correctly, the tests environment should either have `libatc_router.so` in a system directory (like /usr/lib), or run statically by using a command like `go test -ldflags="-extldflags=-static" ...`