### PR TITLE
feat: expression_validate function

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: ['-DDEFINE_ATC_ROUTER_FFI=1']

--- a/atc-router.go
+++ b/atc-router.go
@@ -1,7 +1,6 @@
 package goatcrouter
 
 // #cgo CFLAGS: -DDEFINE_ATC_ROUTER_FFI=1
-// #cgo CFLAGS: -DDEFINE_ATC_ROUTER_EXPR_VALIDATION=1
 // #cgo LDFLAGS: -L/tmp/lib -latc_router
 // #include "atc-router.h"
 import "C"

--- a/atc-router.go
+++ b/atc-router.go
@@ -123,7 +123,7 @@ const (
 )
 
 var (
-	fieldsBuf = []C.uchar{}
+	fieldsBuf = []byte{}
 	fieldsLen = C.ulong(defaultMaxFieldSize * defaultNumFields)
 	fieldsNum = C.ulong(defaultNumFields)
 	errorBuf  = [errBufsize]C.uchar{}
@@ -145,7 +145,7 @@ func ValidateExpression(s Schema, atc string) *ValidationResult {
 loop:
 	for {
 		if len(fieldsBuf) < int(fieldsLen) {
-			fieldsBuf = make([]C.uchar, fieldsLen)
+			fieldsBuf = make([]byte, fieldsLen)
 		}
 
 		switch C.expression_validate(
@@ -187,12 +187,12 @@ const (
 	BinaryOperatorFlags_CONTAINS
 )
 
-func splitByNulls(b []C.uchar, maxN int) []string {
-	out := make([]string, maxN)
+func splitByNulls(b []byte, n int) []string {
+	out := make([]string, n)
 	pos := 0
 	for i := range out {
-		fieldLen := slices.Index(b[pos:], C.uchar(0))
-		if fieldLen <= 0 {
+		fieldLen := slices.Index(b[pos:], 0)
+		if fieldLen < 0 {
 			break
 		}
 

--- a/atc-router.h
+++ b/atc-router.h
@@ -83,30 +83,54 @@ typedef struct CValue {
 } CValue;
 #endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
 typedef struct BinaryOperatorFlags {
   uint64_t bits;
 } BinaryOperatorFlags;
-#define BinaryOperatorFlags_EQUALS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 0) }
-#define BinaryOperatorFlags_NOT_EQUALS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 1) }
-#define BinaryOperatorFlags_REGEX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 2) }
-#define BinaryOperatorFlags_PREFIX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 3) }
-#define BinaryOperatorFlags_POSTFIX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 4) }
-#define BinaryOperatorFlags_GREATER (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 5) }
-#define BinaryOperatorFlags_GREATER_OR_EQUAL (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 6) }
-#define BinaryOperatorFlags_LESS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 7) }
-#define BinaryOperatorFlags_LESS_OR_EQUAL (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 8) }
-#define BinaryOperatorFlags_IN (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 9) }
-#define BinaryOperatorFlags_NOT_IN (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 10) }
-#define BinaryOperatorFlags_CONTAINS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 11) }
-#define BinaryOperatorFlags_UNUSED (BinaryOperatorFlags){ .bits = (uint64_t)~((((((((((((BinaryOperatorFlags_EQUALS).bits | (BinaryOperatorFlags_NOT_EQUALS).bits) | (BinaryOperatorFlags_REGEX).bits) | (BinaryOperatorFlags_PREFIX).bits) | (BinaryOperatorFlags_POSTFIX).bits) | (BinaryOperatorFlags_GREATER).bits) | (BinaryOperatorFlags_GREATER_OR_EQUAL).bits) | (BinaryOperatorFlags_LESS).bits) | (BinaryOperatorFlags_LESS_OR_EQUAL).bits) | (BinaryOperatorFlags_IN).bits) | (BinaryOperatorFlags_NOT_IN).bits) | (BinaryOperatorFlags_CONTAINS).bits) }
-
 #if defined(DEFINE_ATC_ROUTER_FFI)
-struct Schema *schema_new(void);
+#define BinaryOperatorFlags_EQUALS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 0) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_NOT_EQUALS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 1) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_REGEX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 2) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_PREFIX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 3) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_POSTFIX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 4) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_GREATER (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 5) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_GREATER_OR_EQUAL (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 6) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_LESS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 7) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_LESS_OR_EQUAL (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 8) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_IN (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 9) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_NOT_IN (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 10) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_CONTAINS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 11) }
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define BinaryOperatorFlags_UNUSED (BinaryOperatorFlags){ .bits = (uint64_t)~((((((((((((BinaryOperatorFlags_EQUALS).bits | (BinaryOperatorFlags_NOT_EQUALS).bits) | (BinaryOperatorFlags_REGEX).bits) | (BinaryOperatorFlags_PREFIX).bits) | (BinaryOperatorFlags_POSTFIX).bits) | (BinaryOperatorFlags_GREATER).bits) | (BinaryOperatorFlags_GREATER_OR_EQUAL).bits) | (BinaryOperatorFlags_LESS).bits) | (BinaryOperatorFlags_LESS_OR_EQUAL).bits) | (BinaryOperatorFlags_IN).bits) | (BinaryOperatorFlags_NOT_IN).bits) | (BinaryOperatorFlags_CONTAINS).bits) }
+#endif
 #endif
 
 #if defined(DEFINE_ATC_ROUTER_FFI)
 /**
- * Deallocate the schema object.
+ * Allocate a new context object associated with the schema.
  *
  * # Errors
  *
@@ -118,33 +142,226 @@ struct Schema *schema_new(void);
  *
  * - `schema` must be a valid pointer returned by [`schema_new`].
  */
-void schema_free(struct Schema *schema);
+struct Context *context_new(const struct Schema *schema);
 #endif
 
 #if defined(DEFINE_ATC_ROUTER_FFI)
 /**
- * Add a new field with the specified type to the schema.
+ * Deallocate the context object.
  *
- * # Arguments
+ * # Errors
  *
- * - `schema`: a valid pointer to the [`Schema`] object returned by [`schema_new`].
- * - `field`: the C-style string representing the field name.
- * - `typ`: the type of the field.
- *
- * # Panics
- *
- * This function will panic if the C-style string
- * pointed by `field` is not a valid UTF-8 string.
+ * This function never fails.
  *
  * # Safety
  *
  * Violating any of the following constraints will result in undefined behavior:
  *
- * - `schema` must be a valid pointer returned by [`schema_new`].
- * - `field` must be a valid pointer to a C-style string, must be properly aligned,
- *   and must not have '\0' in the middle.
+ * - `context` must be a valid pointer returned by [`context_new`].
  */
-void schema_add_field(struct Schema *schema, const int8_t *field, enum Type typ);
+void context_free(struct Context *context);
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Add a value associated with a field to the context.
+ * This is useful when you want to match a value against a field in the schema.
+ *
+ * # Arguments
+ *
+ * - `context`: a pointer to the [`Context`] object.
+ * - `field`: the C-style string representing the field name.
+ * - `value`: the value to be added to the context.
+ * - `errbuf`: a buffer to store the error message.
+ * - `errbuf_len`: a pointer to the length of the error message buffer.
+ *
+ * # Returns
+ *
+ * Returns `true` if the value was added successfully, otherwise `false`,
+ * and the error message will be stored in the `errbuf`,
+ * and the length of the error message will be stored in `errbuf_len`.
+ *
+ * # Errors
+ *
+ * This function will return `false` if the value could not be added to the context,
+ * such as when a String value is not a valid UTF-8 string.
+ *
+ * # Panics
+ *
+ * This function will panic if the provided value does not match the schema.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * * `context` must be a valid pointer returned by [`context_new`].
+ * * `field` must be a valid pointer to a C-style string,
+ *   must be properply aligned, and must not have '\0' in the middle.
+ * * `value` must be a valid pointer to a [`CValue`].
+ * * `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
+ *   and it must be properly aligned.
+ * * `errbuf_len` must be vlaid to read and write for `size_of::<usize>()` bytes,
+ *   and it must be properly aligned.
+ */
+bool context_add_value(struct Context *context,
+                       const int8_t *field,
+                       const struct CValue *value,
+                       uint8_t *errbuf,
+                       uintptr_t *errbuf_len);
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Reset the context so that it can be reused.
+ * This is useful when you want to reuse the same context for multiple matches.
+ * This will clear all the values that were added to the context,
+ * but keep the memory allocated for the context.
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `context` must be a valid pointer returned by [`context_new`].
+ */
+void context_reset(struct Context *context);
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Get the result of the context.
+ *
+ * # Arguments
+ *
+ * - `context`: a pointer to the [`Context`] object.
+ * - `uuid_hex`: If not `NULL`, the UUID of the matched matcher will be stored.
+ * - `matched_field`: If not `NULL`, the field name (C-style string) of the matched value will be stored.
+ * - `matched_value`: If the `matched_field` is not `NULL`, the value of the matched field will be stored.
+ * - `matched_value_len`: If the `matched_field` is not `NULL`, the length of the value of the matched field will be stored.
+ * - `capture_names`: A pointer to an array of pointers to the capture names, each element is a non-C-style string pointer.
+ * - `capture_names_len`: A pointer to an array of the length of each capture name.
+ * - `capture_values`: A pointer to an array of pointers to the capture values, each element is a non-C-style string pointer.
+ * - `capture_values_len`: A pointer to an array of the length of each capture value.
+ *
+ * # Returns
+ *
+ * Returns the number of captures that are stored in the context.
+ *
+ * # Lifetimes
+ *
+ * The string pointers stored in `matched_value`, `capture_names`, and `capture_values`
+ * might be invalidated if any of the following operations are happened:
+ *
+ * - The `context` was deallocated.
+ * - The `context` was reset by [`context_reset`].
+ *
+ * # Panics
+ *
+ * This function will panic if the `matched_field` is not a valid UTF-8 string.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `context` must be a valid pointer returned by [`context_new`],
+ *    must be passed to [`router_execute`] before calling this function,
+ *    and must not be reset by [`context_reset`] before calling this function.
+ * - If `uuid_hex` is not `NULL`, `uuid_hex` must be valid to read and write for
+ *   `16 * size_of::<u8>()` bytes, and it must be properly aligned.
+ * - If `matched_field` is not `NULL`,
+ *   `matched_field` must be a vlaid pointer to a C-style string,
+ *   must be properly aligned, and must not have '\0' in the middle.
+ * - If `matched_value` is not `NULL`,
+ *   `matched_value` must be valid to read and write for
+ *   `mem::size_of::<*const u8>()` bytes, and it must be properly aligned.
+ * - If `matched_value` is not `NULL`, `matched_value_len` must be valid to read and write for
+ *   `size_of::<usize>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_names` must be valid to read and write for
+ *   `<captures> * size_of::<*const u8>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_names_len` must be valid to read and write for
+ *   `<captures> * size_of::<usize>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_values` must be valid to read and write for
+ *   `<captures> * size_of::<*const u8>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_values_len` must be valid to read and write for
+ *   `<captures> * size_of::<usize>()` bytes, and it must be properly aligned.
+ *
+ * Note: You should get the `<captures>` by calling this function and set every pointer
+ * except the `context` to `NULL` to get the number of captures.
+ */
+intptr_t context_get_result(const struct Context *context,
+                            uint8_t *uuid_hex,
+                            const int8_t *matched_field,
+                            const uint8_t **matched_value,
+                            uintptr_t *matched_value_len,
+                            const uint8_t **capture_names,
+                            uintptr_t *capture_names_len,
+                            const uint8_t **capture_values,
+                            uintptr_t *capture_values_len);
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Validates an ATC expression against a schema.
+ *
+ * # Arguments
+ *
+ * - `atc`: a C-style string representing the ATC expression.
+ * - `schema`: a valid pointer to a [`Schema`] object, as returned by [`schema_new`].
+ * - `fields_buf`: a buffer for storing the fields used in the expression.
+ * - `fields_len`: a pointer to the length of `fields_buf`.
+ * - `fields_total`: a pointer for storing the total number of fields.
+ * - `operators`: a pointer for storing the bitflags representing used operators.
+ * - `errbuf`: a buffer to store any error messages.
+ * - `errbuf_len`: a pointer to the length of the error message buffer.
+ *
+ * # Returns
+ *
+ * An integer indicating the validation result:
+ * - `ATC_ROUTER_EXPRESSION_VALIDATE_OK` (0): Validation succeeded.
+ * - `ATC_ROUTER_EXPRESSION_VALIDATE_FAILED` (1): Validation failed; `errbuf` and `errbuf_len` will be updated with an error message.
+ * - `ATC_ROUTER_EXPRESSION_VALIDATE_BUF_TOO_SMALL` (2): The provided `fields_buf` is too small.
+ *
+ * If `fields_buf` is non-null and `fields_len` is sufficient, this function writes the used fields to `fields_buf`,
+ * each field terminated by `\0`. It updates `fields_len` with the required buffer length and stores the total number of fields in `fields_total`.
+ *
+ * If `fields_buf` is non-null but `fields_len` is insufficient, it writes the required buffer length to `fields_len`
+ * and the total number of fields to `fields_total`, then returns `ATC_ROUTER_EXPRESSION_VALIDATE_BUF_TOO_SMALL`.
+ *
+ * If `operators` is non-null, it writes the used operators as bitflags to the provided pointer.
+ * Bitflags are defined by `BinaryOperatorFlags` and must exclude bits from `BinaryOperatorFlags::UNUSED`.
+ *
+ * # Panics
+ *
+ * This function will panic if:
+ *
+ * - `atc` does not point to a valid C-style string.
+ * - `fields_len` or `fields_total` are null when `fields_buf` is non-null.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints results in undefined behavior:
+ *
+ * - `atc` must be a valid pointer to a C-style string, properly aligned, and must not contain an internal `\0`.
+ * - `schema` must be a valid pointer returned by [`schema_new`].
+ * - `fields_buf`, if non-null, must be valid for writing `fields_len * size_of::<u8>()` bytes and properly aligned.
+ * - `fields_len` must be a valid pointer to write `size_of::<usize>()` bytes and properly aligned.
+ * - `fields_total` must be a valid pointer to write `size_of::<usize>()` bytes and properly aligned.
+ * - `operators` must be a valid pointer to write `size_of::<u64>()` bytes and properly aligned.
+ * - `errbuf` must be valid for reading and writing `errbuf_len * size_of::<u8>()` bytes and properly aligned.
+ * - `errbuf_len` must be a valid pointer for reading and writing `size_of::<usize>()` bytes and properly aligned.
+ * - If `fields_buf` is non-null, then `fields_len` and `fields_total` must also be non-null to store the buffer length used and total field count.
+ */
+int64_t expression_validate(const uint8_t *atc,
+                            const struct Schema *schema,
+                            uint8_t *fields_buf,
+                            uintptr_t *fields_len,
+                            uintptr_t *fields_total,
+                            uint64_t *operators,
+                            uint8_t *errbuf,
+                            uintptr_t *errbuf_len);
 #endif
 
 #if defined(DEFINE_ATC_ROUTER_FFI)
@@ -345,8 +562,12 @@ uintptr_t router_get_fields(const struct Router *router,
 #endif
 
 #if defined(DEFINE_ATC_ROUTER_FFI)
+struct Schema *schema_new(void);
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
 /**
- * Allocate a new context object associated with the schema.
+ * Deallocate the schema object.
  *
  * # Errors
  *
@@ -358,236 +579,31 @@ uintptr_t router_get_fields(const struct Router *router,
  *
  * - `schema` must be a valid pointer returned by [`schema_new`].
  */
-struct Context *context_new(const struct Schema *schema);
+void schema_free(struct Schema *schema);
 #endif
 
 #if defined(DEFINE_ATC_ROUTER_FFI)
 /**
- * Deallocate the context object.
- *
- * # Errors
- *
- * This function never fails.
- *
- * # Safety
- *
- * Violating any of the following constraints will result in undefined behavior:
- *
- * - `context` must be a valid pointer returned by [`context_new`].
- */
-void context_free(struct Context *context);
-#endif
-
-#if defined(DEFINE_ATC_ROUTER_FFI)
-/**
- * Add a value associated with a field to the context.
- * This is useful when you want to match a value against a field in the schema.
+ * Add a new field with the specified type to the schema.
  *
  * # Arguments
  *
- * - `context`: a pointer to the [`Context`] object.
- * - `field`: the C-style string representing the field name.
- * - `value`: the value to be added to the context.
- * - `errbuf`: a buffer to store the error message.
- * - `errbuf_len`: a pointer to the length of the error message buffer.
- *
- * # Returns
- *
- * Returns `true` if the value was added successfully, otherwise `false`,
- * and the error message will be stored in the `errbuf`,
- * and the length of the error message will be stored in `errbuf_len`.
- *
- * # Errors
- *
- * This function will return `false` if the value could not be added to the context,
- * such as when a String value is not a valid UTF-8 string.
- *
- * # Panics
- *
- * This function will panic if the provided value does not match the schema.
- *
- * # Safety
- *
- * Violating any of the following constraints will result in undefined behavior:
- *
- * * `context` must be a valid pointer returned by [`context_new`].
- * * `field` must be a valid pointer to a C-style string,
- *   must be properply aligned, and must not have '\0' in the middle.
- * * `value` must be a valid pointer to a [`CValue`].
- * * `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
- *   and it must be properly aligned.
- * * `errbuf_len` must be vlaid to read and write for `size_of::<usize>()` bytes,
- *   and it must be properly aligned.
- */
-bool context_add_value(struct Context *context,
-                       const int8_t *field,
-                       const struct CValue *value,
-                       uint8_t *errbuf,
-                       uintptr_t *errbuf_len);
-#endif
-
-#if defined(DEFINE_ATC_ROUTER_FFI)
-/**
- * Reset the context so that it can be reused.
- * This is useful when you want to reuse the same context for multiple matches.
- * This will clear all the values that were added to the context,
- * but keep the memory allocated for the context.
- *
- * # Errors
- *
- * This function never fails.
- *
- * # Safety
- *
- * Violating any of the following constraints will result in undefined behavior:
- *
- * - `context` must be a valid pointer returned by [`context_new`].
- */
-void context_reset(struct Context *context);
-#endif
-
-#if defined(DEFINE_ATC_ROUTER_FFI)
-/**
- * Get the result of the context.
- *
- * # Arguments
- *
- * - `context`: a pointer to the [`Context`] object.
- * - `uuid_hex`: If not `NULL`, the UUID of the matched matcher will be stored.
- * - `matched_field`: If not `NULL`, the field name (C-style string) of the matched value will be stored.
- * - `matched_value`: If the `matched_field` is not `NULL`, the value of the matched field will be stored.
- * - `matched_value_len`: If the `matched_field` is not `NULL`, the length of the value of the matched field will be stored.
- * - `capture_names`: A pointer to an array of pointers to the capture names, each element is a non-C-style string pointer.
- * - `capture_names_len`: A pointer to an array of the length of each capture name.
- * - `capture_values`: A pointer to an array of pointers to the capture values, each element is a non-C-style string pointer.
- * - `capture_values_len`: A pointer to an array of the length of each capture value.
- *
- * # Returns
- *
- * Returns the number of captures that are stored in the context.
- *
- * # Lifetimes
- *
- * The string pointers stored in `matched_value`, `capture_names`, and `capture_values`
- * might be invalidated if any of the following operations are happened:
- *
- * - The `context` was deallocated.
- * - The `context` was reset by [`context_reset`].
- *
- * # Panics
- *
- * This function will panic if the `matched_field` is not a valid UTF-8 string.
- *
- * # Safety
- *
- * Violating any of the following constraints will result in undefined behavior:
- *
- * - `context` must be a valid pointer returned by [`context_new`],
- *    must be passed to [`router_execute`] before calling this function,
- *    and must not be reset by [`context_reset`] before calling this function.
- * - If `uuid_hex` is not `NULL`, `uuid_hex` must be valid to read and write for
- *   `16 * size_of::<u8>()` bytes, and it must be properly aligned.
- * - If `matched_field` is not `NULL`,
- *   `matched_field` must be a vlaid pointer to a C-style string,
- *   must be properly aligned, and must not have '\0' in the middle.
- * - If `matched_value` is not `NULL`,
- *   `matched_value` must be valid to read and write for
- *   `mem::size_of::<*const u8>()` bytes, and it must be properly aligned.
- * - If `matched_value` is not `NULL`, `matched_value_len` must be valid to read and write for
- *   `size_of::<usize>()` bytes, and it must be properly aligned.
- * - If `uuid_hex` is not `NULL`, `capture_names` must be valid to read and write for
- *   `<captures> * size_of::<*const u8>()` bytes, and it must be properly aligned.
- * - If `uuid_hex` is not `NULL`, `capture_names_len` must be valid to read and write for
- *   `<captures> * size_of::<usize>()` bytes, and it must be properly aligned.
- * - If `uuid_hex` is not `NULL`, `capture_values` must be valid to read and write for
- *   `<captures> * size_of::<*const u8>()` bytes, and it must be properly aligned.
- * - If `uuid_hex` is not `NULL`, `capture_values_len` must be valid to read and write for
- *   `<captures> * size_of::<usize>()` bytes, and it must be properly aligned.
- *
- * Note: You should get the `<captures>` by calling this function and set every pointer
- * except the `context` to `NULL` to get the number of captures.
- */
-intptr_t context_get_result(const struct Context *context,
-                            uint8_t *uuid_hex,
-                            const int8_t *matched_field,
-                            const uint8_t **matched_value,
-                            uintptr_t *matched_value_len,
-                            const uint8_t **capture_names,
-                            uintptr_t *capture_names_len,
-                            const uint8_t **capture_values,
-                            uintptr_t *capture_values_len);
-#endif
-
-#if defined(DEFINE_ATC_ROUTER_FFI)
-/**
- * Validate the ATC expression with the schema.
- *
- * # Arguments
- *
- * - `atc`: the C-style string representing the ATC expression.
  * - `schema`: a valid pointer to the [`Schema`] object returned by [`schema_new`].
- * - `fields_buf`: a buffer to store the used fields.
- * - `fields_len`: a pointer to the length of the fields buffer.
- * - `fields_total`: a pointer for saving the total number of the fields.
- * - `operators`: a pointer for saving the used operators with bitflags.
- * - `errbuf`: a buffer to store the error message.
- * - `errbuf_len`: a pointer to the length of the error message buffer.
- *
- * # Returns
- *
- * Returns an integer value indicating the validation result:
- * - ATC_ROUTER_EXPRESSION_VALIDATE_OK(0) if validation is passed.
- * - ATC_ROUTER_EXPRESSION_VALIDATE_FAILED(1) if validation is failed.
- * - ATC_ROUTER_EXPRESSION_VALIDATE_BUF_TOO_SMALL(2) if the provided fields buffer is not enough.
- *
- * If `fields_buf` is null and `fields_len` or `fields_total` is non-null, it will write
- * the required buffer length and the total number of fields to the provided pointers.
- * If `fields_buf` is non-null, and `fields_len` is enough for the required buffer length,
- * it will write the used fields to the buffer separated by '\0' and the total number of fields
- * to the `fields_total`, and `fields_len` will be updated with the total buffer length.
- * If `fields_buf` is non-null, and `fields_len` is not enough for the required buffer length,
- * it will write the required buffer length to the `fields_len`, and the total number of fields
- * to the `fields_total`, and return `2`.
- * If `operators` is non-null, it will write the used operators with bitflags to the provided pointer.
- * The bitflags is defined by `BinaryOperatorFlags` and it must not contain any bits from `BinaryOperatorFlags::UNUSED`.
- *
+ * - `field`: the C-style string representing the field name.
+ * - `typ`: the type of the field.
  *
  * # Panics
  *
- * This function will panic when:
- *
- * - `atc` doesn't point to a valid C-style string.
- * - `fields_len` and `fields_total` are null when `fields_buf` is non-null.
+ * This function will panic if the C-style string
+ * pointed by `field` is not a valid UTF-8 string.
  *
  * # Safety
  *
  * Violating any of the following constraints will result in undefined behavior:
  *
- * - `atc` must be a valid pointer to a C-style string, must be properly aligned,
- *    and must not have '\0' in the middle.
  * - `schema` must be a valid pointer returned by [`schema_new`].
- * - `fields_buf` must be a valid to write for `fields_len * size_of::<u8>()` bytes,
- *    and it must be properly aligned if non-null.
- * - `fields_len` must be a valid to write for `size_of::<usize>()` bytes,
- *    and it must be properly aligned if non-null.
- * - `fields_total` must be a valid to write for `size_of::<usize>()` bytes,
- *    and it must be properly aligned if non-null.
- * - `operators` must be a valid to write for `size_of::<u64>()` bytes,
- *    and it must be properly aligned if non-null.
- * - `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
- *    and it must be properly aligned.
- * - `errbuf_len` must be valid to read and write for `size_of::<usize>()` bytes,
- *    and it must be properly aligned.
- * - If `fields_buf` is non-null, `fields_len` and `fields_total` must be non-null.
- * - If `fields_buf` is null, `fields_len` and `fields_total` can be non-null
- *   for writing required buffer length and total number of fields.
+ * - `field` must be a valid pointer to a C-style string, must be properly aligned,
+ *   and must not have '\0' in the middle.
  */
-int64_t expression_validate(const uint8_t *atc,
-                            const struct Schema *schema,
-                            uint8_t *fields_buf,
-                            uintptr_t *fields_len,
-                            uintptr_t *fields_total,
-                            uint64_t *operators,
-                            uint8_t *errbuf,
-                            uintptr_t *errbuf_len);
+void schema_add_field(struct Schema *schema, const int8_t *field, enum Type typ);
 #endif

--- a/atc-router.h
+++ b/atc-router.h
@@ -5,7 +5,21 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define ERR_BUF_MAX_LEN 2048
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define ERR_BUF_MAX_LEN 4096
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define ATC_ROUTER_EXPRESSION_VALIDATE_OK 0
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define ATC_ROUTER_EXPRESSION_VALIDATE_FAILED 1
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+#define ATC_ROUTER_EXPRESSION_VALIDATE_BUF_TOO_SMALL 2
+#endif
 
 typedef enum Type {
   Type_String,
@@ -21,66 +35,478 @@ typedef struct Router Router;
 
 typedef struct Schema Schema;
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
 typedef enum CValue_Tag {
-  CValue_CString,
-  CValue_CIpCidr,
-  CValue_CIpAddr,
-  CValue_CInt,
+#if defined(DEFINE_ATC_ROUTER_FFI)
+  CValue_Str,
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+  CValue_IpCidr,
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+  CValue_IpAddr,
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
+  CValue_Int,
+#endif
 } CValue_Tag;
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+typedef struct CValue_Str_Body {
+  const uint8_t *_0;
+  uintptr_t _1;
+} CValue_Str_Body;
+#endif
 
 typedef struct CValue {
   CValue_Tag tag;
   union {
+#if defined(DEFINE_ATC_ROUTER_FFI)
+    CValue_Str_Body str;
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
     struct {
-      const int8_t *c_string;
+      const uint8_t *ip_cidr;
     };
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
     struct {
-      const int8_t *c_ip_cidr;
+      const uint8_t *ip_addr;
     };
+#endif
+#if defined(DEFINE_ATC_ROUTER_FFI)
     struct {
-      const int8_t *c_ip_addr;
+      int64_t int_;
     };
-    struct {
-      int64_t c_int;
-    };
+#endif
   };
 } CValue;
+#endif
 
+typedef struct BinaryOperatorFlags {
+  uint64_t bits;
+} BinaryOperatorFlags;
+#define BinaryOperatorFlags_EQUALS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 0) }
+#define BinaryOperatorFlags_NOT_EQUALS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 1) }
+#define BinaryOperatorFlags_REGEX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 2) }
+#define BinaryOperatorFlags_PREFIX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 3) }
+#define BinaryOperatorFlags_POSTFIX (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 4) }
+#define BinaryOperatorFlags_GREATER (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 5) }
+#define BinaryOperatorFlags_GREATER_OR_EQUAL (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 6) }
+#define BinaryOperatorFlags_LESS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 7) }
+#define BinaryOperatorFlags_LESS_OR_EQUAL (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 8) }
+#define BinaryOperatorFlags_IN (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 9) }
+#define BinaryOperatorFlags_NOT_IN (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 10) }
+#define BinaryOperatorFlags_CONTAINS (BinaryOperatorFlags){ .bits = (uint64_t)(1 << 11) }
+#define BinaryOperatorFlags_UNUSED (BinaryOperatorFlags){ .bits = (uint64_t)~((((((((((((BinaryOperatorFlags_EQUALS).bits | (BinaryOperatorFlags_NOT_EQUALS).bits) | (BinaryOperatorFlags_REGEX).bits) | (BinaryOperatorFlags_PREFIX).bits) | (BinaryOperatorFlags_POSTFIX).bits) | (BinaryOperatorFlags_GREATER).bits) | (BinaryOperatorFlags_GREATER_OR_EQUAL).bits) | (BinaryOperatorFlags_LESS).bits) | (BinaryOperatorFlags_LESS_OR_EQUAL).bits) | (BinaryOperatorFlags_IN).bits) | (BinaryOperatorFlags_NOT_IN).bits) | (BinaryOperatorFlags_CONTAINS).bits) }
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
 struct Schema *schema_new(void);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Deallocate the schema object.
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `schema` must be a valid pointer returned by [`schema_new`].
+ */
 void schema_free(struct Schema *schema);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Add a new field with the specified type to the schema.
+ *
+ * # Arguments
+ *
+ * - `schema`: a valid pointer to the [`Schema`] object returned by [`schema_new`].
+ * - `field`: the C-style string representing the field name.
+ * - `typ`: the type of the field.
+ *
+ * # Panics
+ *
+ * This function will panic if the C-style string
+ * pointed by `field` is not a valid UTF-8 string.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `schema` must be a valid pointer returned by [`schema_new`].
+ * - `field` must be a valid pointer to a C-style string, must be properly aligned,
+ *   and must not have '\0' in the middle.
+ */
 void schema_add_field(struct Schema *schema, const int8_t *field, enum Type typ);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Create a new router object associated with the schema.
+ *
+ * # Arguments
+ *
+ * - `schema`: a valid pointer to the [`Schema`] object returned by [`schema_new`].
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `schema` must be a valid pointer returned by [`schema_new`].
+ */
 struct Router *router_new(const struct Schema *schema);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Deallocate the router object.
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `router` must be a valid pointer returned by [`router_new`].
+ */
 void router_free(struct Router *router);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Add a new matcher to the router.
+ *
+ * # Arguments
+ *
+ * - `router`: a pointer to the [`Router`] object returned by [`router_new`].
+ * - `priority`: the priority of the matcher, higher value means higher priority,
+ *   and the matcher with the highest priority will be executed first.
+ * - `uuid`: the C-style string representing the UUID of the matcher.
+ * - `atc`: the C-style string representing the ATC expression.
+ * - `errbuf`: a buffer to store the error message.
+ * - `errbuf_len`: a pointer to the length of the error message buffer.
+ *
+ * # Returns
+ *
+ * Returns `true` if the matcher was added successfully, otherwise `false`,
+ * and the error message will be stored in the `errbuf`,
+ * and the length of the error message will be stored in `errbuf_len`.
+ *
+ * # Errors
+ *
+ * This function will return `false` if the matcher could not be added to the router,
+ * such as duplicate UUID, and invalid ATC expression.
+ *
+ * # Panics
+ *
+ * This function will panic when:
+ *
+ * - `uuid` doesn't point to a ASCII sequence representing a valid 128-bit UUID.
+ * - `atc` doesn't point to a valid C-style string.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `router` must be a valid pointer returned by [`router_new`].
+ * - `uuid` must be a valid pointer to a C-style string, must be properly aligned,
+ *    and must not have '\0' in the middle.
+ * - `atc` must be a valid pointer to a C-style string, must be properly aligned,
+ *    and must not have '\0' in the middle.
+ * - `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
+ *    and it must be properly aligned.
+ * - `errbuf_len` must be valid to read and write for `size_of::<usize>()` bytes,
+ *    and it must be properly aligned.
+ */
 bool router_add_matcher(struct Router *router,
                         uintptr_t priority,
                         const int8_t *uuid,
                         const int8_t *atc,
                         uint8_t *errbuf,
                         uintptr_t *errbuf_len);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Remove a matcher from the router.
+ *
+ * # Arguments
+ * - `router`: a pointer to the [`Router`] object returned by [`router_new`].
+ * - `priority`: the priority of the matcher to be removed.
+ * - `uuid`: the C-style string representing the UUID of the matcher to be removed.
+ *
+ * # Returns
+ *
+ * Returns `true` if the matcher was removed successfully, otherwise `false`,
+ * such as when the matcher with the specified UUID doesn't exist or
+ * the priority doesn't match the UUID.
+ *
+ * # Panics
+ *
+ * This function will panic when `uuid` doesn't point to a ASCII sequence
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `router` must be a valid pointer returned by [`router_new`].
+ * - `uuid` must be a valid pointer to a C-style string, must be properly aligned,
+ *    and must not have '\0' in the middle.
+ */
 bool router_remove_matcher(struct Router *router, uintptr_t priority, const int8_t *uuid);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Execute the router with the context.
+ *
+ * # Arguments
+ *
+ * - `router`: a pointer to the [`Router`] object returned by [`router_new`].
+ * - `context`: a pointer to the [`Context`] object.
+ *
+ * # Returns
+ *
+ * Returns `true` if found a match, `false` means no match found.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `router` must be a valid pointer returned by [`router_new`].
+ * - `context` must be a valid pointer returned by [`context_new`],
+ *    and must be reset by [`context_reset`] before calling this function
+ *    if you want to reuse the same context for multiple matches.
+ */
 bool router_execute(const struct Router *router, struct Context *context);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Get the de-duplicated fields that are actually used in the router.
+ * This is useful when you want to know what fields are actually used in the router,
+ * so you can generate their values on-demand.
+ *
+ * # Arguments
+ *
+ * - `router`: a pointer to the [`Router`] object returned by [`router_new`].
+ * - `fields`: a pointer to an array of pointers to the field names
+ *    (NOT C-style strings) that are actually used in the router, which will be filled in.
+ *    if `fields` is `NULL`, this function will only return the number of fields used
+ *    in the router.
+ * - `fields_len`: a pointer to an array of the length of each field name.
+ *
+ * # Lifetimes
+ *
+ * The string pointers stored in `fields` might be invalidated if any of the following
+ * operations are happened:
+ *
+ * - The `router` was deallocated.
+ * - A new matcher was added to the `router`.
+ * - A matcher was removed from the `router`.
+ *
+ * # Returns
+ *
+ * Returns the number of fields that are actually used in the router.
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `router` must be a valid pointer returned by [`router_new`].
+ * - If `fields` is not `NULL`, `fields` must be valid to read and write for
+ *   `fields_len * size_of::<*const u8>()` bytes, and it must be properly aligned.
+ * - If `fields` is not `NULL`, `fields_len` must be valid to read and write for
+ *   `size_of::<usize>()` bytes, and it must be properly aligned.
+ * - DO NOT write the memory pointed by the elements of `fields`.
+ * - DO NOT access the memory pointed by the elements of `fields`
+ *   after it becomes invalid, see the `Lifetimes` section.
+ */
 uintptr_t router_get_fields(const struct Router *router,
                             const uint8_t **fields,
                             uintptr_t *fields_len);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Allocate a new context object associated with the schema.
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `schema` must be a valid pointer returned by [`schema_new`].
+ */
 struct Context *context_new(const struct Schema *schema);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Deallocate the context object.
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `context` must be a valid pointer returned by [`context_new`].
+ */
 void context_free(struct Context *context);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Add a value associated with a field to the context.
+ * This is useful when you want to match a value against a field in the schema.
+ *
+ * # Arguments
+ *
+ * - `context`: a pointer to the [`Context`] object.
+ * - `field`: the C-style string representing the field name.
+ * - `value`: the value to be added to the context.
+ * - `errbuf`: a buffer to store the error message.
+ * - `errbuf_len`: a pointer to the length of the error message buffer.
+ *
+ * # Returns
+ *
+ * Returns `true` if the value was added successfully, otherwise `false`,
+ * and the error message will be stored in the `errbuf`,
+ * and the length of the error message will be stored in `errbuf_len`.
+ *
+ * # Errors
+ *
+ * This function will return `false` if the value could not be added to the context,
+ * such as when a String value is not a valid UTF-8 string.
+ *
+ * # Panics
+ *
+ * This function will panic if the provided value does not match the schema.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * * `context` must be a valid pointer returned by [`context_new`].
+ * * `field` must be a valid pointer to a C-style string,
+ *   must be properply aligned, and must not have '\0' in the middle.
+ * * `value` must be a valid pointer to a [`CValue`].
+ * * `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
+ *   and it must be properly aligned.
+ * * `errbuf_len` must be vlaid to read and write for `size_of::<usize>()` bytes,
+ *   and it must be properly aligned.
+ */
 bool context_add_value(struct Context *context,
                        const int8_t *field,
                        const struct CValue *value,
                        uint8_t *errbuf,
                        uintptr_t *errbuf_len);
+#endif
 
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Reset the context so that it can be reused.
+ * This is useful when you want to reuse the same context for multiple matches.
+ * This will clear all the values that were added to the context,
+ * but keep the memory allocated for the context.
+ *
+ * # Errors
+ *
+ * This function never fails.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `context` must be a valid pointer returned by [`context_new`].
+ */
+void context_reset(struct Context *context);
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Get the result of the context.
+ *
+ * # Arguments
+ *
+ * - `context`: a pointer to the [`Context`] object.
+ * - `uuid_hex`: If not `NULL`, the UUID of the matched matcher will be stored.
+ * - `matched_field`: If not `NULL`, the field name (C-style string) of the matched value will be stored.
+ * - `matched_value`: If the `matched_field` is not `NULL`, the value of the matched field will be stored.
+ * - `matched_value_len`: If the `matched_field` is not `NULL`, the length of the value of the matched field will be stored.
+ * - `capture_names`: A pointer to an array of pointers to the capture names, each element is a non-C-style string pointer.
+ * - `capture_names_len`: A pointer to an array of the length of each capture name.
+ * - `capture_values`: A pointer to an array of pointers to the capture values, each element is a non-C-style string pointer.
+ * - `capture_values_len`: A pointer to an array of the length of each capture value.
+ *
+ * # Returns
+ *
+ * Returns the number of captures that are stored in the context.
+ *
+ * # Lifetimes
+ *
+ * The string pointers stored in `matched_value`, `capture_names`, and `capture_values`
+ * might be invalidated if any of the following operations are happened:
+ *
+ * - The `context` was deallocated.
+ * - The `context` was reset by [`context_reset`].
+ *
+ * # Panics
+ *
+ * This function will panic if the `matched_field` is not a valid UTF-8 string.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `context` must be a valid pointer returned by [`context_new`],
+ *    must be passed to [`router_execute`] before calling this function,
+ *    and must not be reset by [`context_reset`] before calling this function.
+ * - If `uuid_hex` is not `NULL`, `uuid_hex` must be valid to read and write for
+ *   `16 * size_of::<u8>()` bytes, and it must be properly aligned.
+ * - If `matched_field` is not `NULL`,
+ *   `matched_field` must be a vlaid pointer to a C-style string,
+ *   must be properly aligned, and must not have '\0' in the middle.
+ * - If `matched_value` is not `NULL`,
+ *   `matched_value` must be valid to read and write for
+ *   `mem::size_of::<*const u8>()` bytes, and it must be properly aligned.
+ * - If `matched_value` is not `NULL`, `matched_value_len` must be valid to read and write for
+ *   `size_of::<usize>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_names` must be valid to read and write for
+ *   `<captures> * size_of::<*const u8>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_names_len` must be valid to read and write for
+ *   `<captures> * size_of::<usize>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_values` must be valid to read and write for
+ *   `<captures> * size_of::<*const u8>()` bytes, and it must be properly aligned.
+ * - If `uuid_hex` is not `NULL`, `capture_values_len` must be valid to read and write for
+ *   `<captures> * size_of::<usize>()` bytes, and it must be properly aligned.
+ *
+ * Note: You should get the `<captures>` by calling this function and set every pointer
+ * except the `context` to `NULL` to get the number of captures.
+ */
 intptr_t context_get_result(const struct Context *context,
                             uint8_t *uuid_hex,
                             const int8_t *matched_field,
@@ -90,3 +516,78 @@ intptr_t context_get_result(const struct Context *context,
                             uintptr_t *capture_names_len,
                             const uint8_t **capture_values,
                             uintptr_t *capture_values_len);
+#endif
+
+#if defined(DEFINE_ATC_ROUTER_FFI)
+/**
+ * Validate the ATC expression with the schema.
+ *
+ * # Arguments
+ *
+ * - `atc`: the C-style string representing the ATC expression.
+ * - `schema`: a valid pointer to the [`Schema`] object returned by [`schema_new`].
+ * - `fields_buf`: a buffer to store the used fields.
+ * - `fields_len`: a pointer to the length of the fields buffer.
+ * - `fields_total`: a pointer for saving the total number of the fields.
+ * - `operators`: a pointer for saving the used operators with bitflags.
+ * - `errbuf`: a buffer to store the error message.
+ * - `errbuf_len`: a pointer to the length of the error message buffer.
+ *
+ * # Returns
+ *
+ * Returns an integer value indicating the validation result:
+ * - ATC_ROUTER_EXPRESSION_VALIDATE_OK(0) if validation is passed.
+ * - ATC_ROUTER_EXPRESSION_VALIDATE_FAILED(1) if validation is failed.
+ * - ATC_ROUTER_EXPRESSION_VALIDATE_BUF_TOO_SMALL(2) if the provided fields buffer is not enough.
+ *
+ * If `fields_buf` is null and `fields_len` or `fields_total` is non-null, it will write
+ * the required buffer length and the total number of fields to the provided pointers.
+ * If `fields_buf` is non-null, and `fields_len` is enough for the required buffer length,
+ * it will write the used fields to the buffer separated by '\0' and the total number of fields
+ * to the `fields_total`, and `fields_len` will be updated with the total buffer length.
+ * If `fields_buf` is non-null, and `fields_len` is not enough for the required buffer length,
+ * it will write the required buffer length to the `fields_len`, and the total number of fields
+ * to the `fields_total`, and return `2`.
+ * If `operators` is non-null, it will write the used operators with bitflags to the provided pointer.
+ * The bitflags is defined by `BinaryOperatorFlags` and it must not contain any bits from `BinaryOperatorFlags::UNUSED`.
+ *
+ *
+ * # Panics
+ *
+ * This function will panic when:
+ *
+ * - `atc` doesn't point to a valid C-style string.
+ * - `fields_len` and `fields_total` are null when `fields_buf` is non-null.
+ *
+ * # Safety
+ *
+ * Violating any of the following constraints will result in undefined behavior:
+ *
+ * - `atc` must be a valid pointer to a C-style string, must be properly aligned,
+ *    and must not have '\0' in the middle.
+ * - `schema` must be a valid pointer returned by [`schema_new`].
+ * - `fields_buf` must be a valid to write for `fields_len * size_of::<u8>()` bytes,
+ *    and it must be properly aligned if non-null.
+ * - `fields_len` must be a valid to write for `size_of::<usize>()` bytes,
+ *    and it must be properly aligned if non-null.
+ * - `fields_total` must be a valid to write for `size_of::<usize>()` bytes,
+ *    and it must be properly aligned if non-null.
+ * - `operators` must be a valid to write for `size_of::<u64>()` bytes,
+ *    and it must be properly aligned if non-null.
+ * - `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
+ *    and it must be properly aligned.
+ * - `errbuf_len` must be valid to read and write for `size_of::<usize>()` bytes,
+ *    and it must be properly aligned.
+ * - If `fields_buf` is non-null, `fields_len` and `fields_total` must be non-null.
+ * - If `fields_buf` is null, `fields_len` and `fields_total` can be non-null
+ *   for writing required buffer length and total number of fields.
+ */
+int64_t expression_validate(const uint8_t *atc,
+                            const struct Schema *schema,
+                            uint8_t *fields_buf,
+                            uintptr_t *fields_len,
+                            uintptr_t *fields_total,
+                            uint64_t *operators,
+                            uint8_t *errbuf,
+                            uintptr_t *errbuf_len);
+#endif

--- a/atc-router_test.go
+++ b/atc-router_test.go
@@ -7,12 +7,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func verify(atc string) error {
-	schema := NewSchema()
-	defer schema.Free()
+type field struct {
+	f string
+	t FieldType
+}
 
-	schema.AddField("http.path", String)
-	schema.AddField("tcp.port", Int)
+func newSchema(fields ...field) *Schema {
+	schema := NewSchema()
+	for _, fld := range fields {
+		schema.AddField(fld.f, fld.t)
+	}
+	return schema
+}
+
+func verify(atc string) error {
+	schema := newSchema(field{"http.path", String}, field{"tcp.port", Int})
+	defer schema.Free()
 
 	router := NewRouter(schema)
 	defer router.Free()
@@ -21,11 +31,8 @@ func verify(atc string) error {
 }
 
 func get_fields(atc string) ([]string, error) {
-	schema := NewSchema()
+	schema := newSchema(field{"http.path", String}, field{"tcp.port", Int})
 	defer schema.Free()
-
-	schema.AddField("http.path", String)
-	schema.AddField("tcp.port", Int)
 
 	router := NewRouter(schema)
 	defer router.Free()
@@ -55,4 +62,20 @@ func Test_GetFields(t *testing.T) {
 	fields, err = get_fields(`tcp.port == 1 && http.path==""`)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []any{"http.path", "tcp.port"}, fields)
+}
+
+func Test_ValidateExpression(t *testing.T) {
+	schema := newSchema(field{"http.path", String}, field{"tcp.port", Int})
+	defer schema.Free()
+
+	res := ValidateExpression(*schema, "tcp.port == 1")
+	require.Equal(t, &ValidationResult{
+		fields:    []string{"tcp.port"},
+		operators: BinaryOperatorFlags_EQUALS,
+	}, res)
+
+	require.Equal(t, &ValidationResult{
+		fields:    []string{"http.path", "tcp.port"},
+		operators: BinaryOperatorFlags_EQUALS + BinaryOperatorFlags_NOT_EQUALS,
+	}, ValidateExpression(*schema, `tcp.port == 1 && http.path!=""`))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/go-atc-router
 
-go 1.19
+go 1.22.1
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
[KOKO-1994](https://konghq.atlassian.net/browse/KOKO-1994)

New `expression_validate` function in atc-router library. Can validate an expression without defining a `Router` object. If valid, returns the set of fields and operators used by the expression.

Depends On #Kong/atc-router#263
JIRA: [KAG-5013](https://konghq.atlassian.net/browse/KAG-5013)

[KAG-5013]: https://konghq.atlassian.net/browse/KAG-5013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KOKO-1994]: https://konghq.atlassian.net/browse/KOKO-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ